### PR TITLE
ACCDT-1238: Add `runner_name` label

### DIFF
--- a/pkg/actionsmetrics/event_reader.go
+++ b/pkg/actionsmetrics/event_reader.go
@@ -137,7 +137,7 @@ func (reader *EventReader) ProcessWorkflowJobEvent(ctx context.Context, event in
 		githubWorkflowJobQueueDurationSeconds.With(labels).Observe(parseResult.QueueTime.Seconds())
 
 	case "completed":
-		githubWorkflowJobsCompletedTotal.With(labels).Inc()
+		githubWorkflowJobsCompletedTotal.With(extraLabel("runner_name", *e.WorkflowJob.RunnerName, labels)).Inc()
 
 		// job_conclusion -> (neutral, success, skipped, cancelled, timed_out, action_required, failure)
 		githubWorkflowJobConclusionsTotal.With(extraLabel("job_conclusion", *e.WorkflowJob.Conclusion, labels)).Inc()

--- a/pkg/actionsmetrics/event_reader.go
+++ b/pkg/actionsmetrics/event_reader.go
@@ -137,7 +137,11 @@ func (reader *EventReader) ProcessWorkflowJobEvent(ctx context.Context, event in
 		githubWorkflowJobQueueDurationSeconds.With(labels).Observe(parseResult.QueueTime.Seconds())
 
 	case "completed":
-		githubWorkflowJobsCompletedTotal.With(extraLabel("runner_name", *e.WorkflowJob.RunnerName, labels)).Inc()
+		workflowCompletedLabels := labels
+		if n := e.WorkflowJob.RunnerName; n != nil {
+			workflowCompletedLabels = extraLabel("runner_name", *n, labels)
+		}
+		githubWorkflowJobsCompletedTotal.With(workflowCompletedLabels).Inc()
 
 		// job_conclusion -> (neutral, success, skipped, cancelled, timed_out, action_required, failure)
 		githubWorkflowJobConclusionsTotal.With(extraLabel("job_conclusion", *e.WorkflowJob.Conclusion, labels)).Inc()

--- a/pkg/actionsmetrics/event_reader.go
+++ b/pkg/actionsmetrics/event_reader.go
@@ -137,11 +137,11 @@ func (reader *EventReader) ProcessWorkflowJobEvent(ctx context.Context, event in
 		githubWorkflowJobQueueDurationSeconds.With(labels).Observe(parseResult.QueueTime.Seconds())
 
 	case "completed":
-		workflowCompletedLabels := labels
+		var rn string
 		if n := e.WorkflowJob.RunnerName; n != nil {
-			workflowCompletedLabels = extraLabel("runner_name", *n, labels)
+			rn = *n
 		}
-		githubWorkflowJobsCompletedTotal.With(workflowCompletedLabels).Inc()
+		githubWorkflowJobsCompletedTotal.With(extraLabel("runner_name", rn, labels)).Inc()
 
 		// job_conclusion -> (neutral, success, skipped, cancelled, timed_out, action_required, failure)
 		githubWorkflowJobConclusionsTotal.With(extraLabel("job_conclusion", *e.WorkflowJob.Conclusion, labels)).Inc()

--- a/pkg/actionsmetrics/metrics.go
+++ b/pkg/actionsmetrics/metrics.go
@@ -175,7 +175,7 @@ var (
 			Name: "github_workflow_jobs_completed_total",
 			Help: "Total count of workflow jobs completed (events where job_status=completed)",
 		},
-		metricLabels(),
+		metricLabels("runner_name"),
 	)
 	githubWorkflowJobFailuresTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{


### PR DESCRIPTION
## Motivation

[ACCDT-1238]

This would allow us to correlate data between runs with their resource use in kubernetes, and deprecate our current custom solution.

## Proposed Changes

This adds the `runner_name` label to `workflow_jobs_completed_total`. We only need one metric to have the `runner_name` label.

`workflow_jobs_completed_total` was chosen since it currently has low cardinality

## Dependencies

This should be merged after both of the PRs below are merged to the fork:
- https://github.com/miroapp/actions-runner-controller/pull/1
- https://github.com/actions/actions-runner-controller/pull/2903