### PR TITLE
ACCDT-1239: reduce cardinality of metrics

### DIFF
--- a/pkg/actionsmetrics/event_reader.go
+++ b/pkg/actionsmetrics/event_reader.go
@@ -193,8 +193,10 @@ func (reader *EventReader) ProcessWorkflowJobEvent(ctx context.Context, event in
 			).Inc()
 		}
 
-		if runTimeSeconds != nil {
-			githubWorkflowJobRunDurationSeconds.With(extraLabel("job_conclusion", *e.WorkflowJob.Conclusion, labels)).Observe(*runTimeSeconds)
+		if *e.WorkflowJob.Conclusion != "cancelled" && *e.WorkflowJob.Conclusion != "skipped" && *e.WorkflowJob.Conclusion != "timed_out" {
+			if runTimeSeconds != nil {
+				githubWorkflowJobRunDurationSeconds.With(extraLabel("job_conclusion", *e.WorkflowJob.Conclusion, labels)).Observe(*runTimeSeconds)
+			}
 		}
 	}
 }

--- a/pkg/actionsmetrics/event_reader.go
+++ b/pkg/actionsmetrics/event_reader.go
@@ -64,6 +64,10 @@ func (reader *EventReader) ProcessWorkflowJobEvent(ctx context.Context, event in
 		keysAndValues = []interface{}{"job_id", fmt.Sprint(*e.WorkflowJob.ID)}
 	)
 
+	if len(e.WorkflowJob.Labels) == 0 {
+		return
+	}
+
 	runsOn := strings.Join(e.WorkflowJob.Labels, `,`)
 	labels["runs_on"] = runsOn
 

--- a/pkg/actionsmetrics/event_reader.go
+++ b/pkg/actionsmetrics/event_reader.go
@@ -75,10 +75,6 @@ func (reader *EventReader) ProcessWorkflowJobEvent(ctx context.Context, event in
 			labels["repository"] = *n
 			keysAndValues = append(keysAndValues, "repository", *n)
 		}
-		if n := e.Repo.FullName; n != nil {
-			labels["repository_full_name"] = *n
-			keysAndValues = append(keysAndValues, "repository_full_name", *n)
-		}
 
 		if e.Repo.Owner != nil {
 			if l := e.Repo.Owner.Login; l != nil {
@@ -98,19 +94,13 @@ func (reader *EventReader) ProcessWorkflowJobEvent(ctx context.Context, event in
 	labels["organization"] = org
 
 	var wn string
-	var hb string
 	if e.WorkflowJob != nil {
 		if n := e.WorkflowJob.WorkflowName; n != nil {
 			wn = *n
 			keysAndValues = append(keysAndValues, "workflow_name", *n)
 		}
-		if n := e.WorkflowJob.HeadBranch; n != nil {
-			hb = *n
-			keysAndValues = append(keysAndValues, "head_branch", *n)
-		}
 	}
 	labels["workflow_name"] = wn
-	labels["head_branch"] = hb
 
 	log := reader.Log.WithValues(keysAndValues...)
 

--- a/pkg/actionsmetrics/metrics.go
+++ b/pkg/actionsmetrics/metrics.go
@@ -146,7 +146,7 @@ func initGithubWorkflowJobRunDurationSeconds(buckets []float64) *prometheus.Hist
 }
 
 var (
-	commonLabels                          = []string{"runs_on", "job_name", "organization", "repository", "repository_full_name", "owner", "workflow_name", "head_branch"}
+	commonLabels                          = []string{"runs_on", "job_name", "organization", "repository", "owner", "workflow_name"}
 	githubWorkflowJobQueueDurationSeconds *prometheus.HistogramVec
 	githubWorkflowJobRunDurationSeconds   *prometheus.HistogramVec
 	githubWorkflowJobConclusionsTotal     = prometheus.NewCounterVec(


### PR DESCRIPTION
## Motivation

[ACCDT-1239]

Currently the volume of metrics is too high due to cardinality. This was remedied before by using metric relabelings, but there are benefits of applying the change directly in the producing code.

## Proposed Changes

- Only store job duration metrics when the conclusion is relevant
- Drop head branch and repository full name
