### PR TITLE
feat: adding label `is_main_branch` to the metrics exported by the controller.

### DIFF
--- a/pkg/actionsmetrics/event_reader.go
+++ b/pkg/actionsmetrics/event_reader.go
@@ -106,6 +106,14 @@ func (reader *EventReader) ProcessWorkflowJobEvent(ctx context.Context, event in
 	}
 	labels["workflow_name"] = wn
 
+	is_main_branch := "false"
+
+	if strings.EqualFold(*e.WorkflowJob.HeadBranch, "main") || strings.EqualFold(*e.WorkflowJob.HeadBranch, "master") {
+		is_main_branch = "true"
+	}
+
+	labels["is_main_branch"] = is_main_branch
+
 	log := reader.Log.WithValues(keysAndValues...)
 
 	// switch on job status


### PR DESCRIPTION
We will add a label to the `github_workflow_job_*` metrics, allowing filtering by:

```
github_workflow_job_conclusions_total{is_main_branch="true|false"}
```

PSHEP-8503