### PR TITLE
feat: Add metrics per specific step in the CI job

### DIFF
--- a/pkg/actionsmetrics/metrics.go
+++ b/pkg/actionsmetrics/metrics.go
@@ -42,10 +42,12 @@ func init() {
 
 	githubWorkflowJobQueueDurationSeconds = initGithubWorkflowJobQueueDurationSeconds(queueBuckets)
 	githubWorkflowJobRunDurationSeconds = initGithubWorkflowJobRunDurationSeconds(runBuckets)
+	githubWorkflowJobStepDurationSeconds = initGithubWorkflowJobStepDurationSeconds(runBuckets)
 
 	metrics.Registry.MustRegister(
 		githubWorkflowJobQueueDurationSeconds,
 		githubWorkflowJobRunDurationSeconds,
+		githubWorkflowJobStepDurationSeconds,
 		githubWorkflowJobConclusionsTotal,
 		githubWorkflowJobsQueuedTotal,
 		githubWorkflowJobsStartedTotal,
@@ -145,10 +147,22 @@ func initGithubWorkflowJobRunDurationSeconds(buckets []float64) *prometheus.Hist
 	)
 }
 
+func initGithubWorkflowJobStepDurationSeconds(buckets []float64) *prometheus.HistogramVec {
+	return prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "github_workflow_job_step_run_duration_seconds",
+			Help:    "Run times for the steps in workflow jobs in seconds",
+			Buckets: buckets,
+		},
+		metricLabels("step_name", "step_number", "step_conclusion", "step_status"),
+	)
+}
+
 var (
 	commonLabels                          = []string{"runs_on", "job_name", "organization", "repository", "owner", "workflow_name", "is_main_branch"}
 	githubWorkflowJobQueueDurationSeconds *prometheus.HistogramVec
 	githubWorkflowJobRunDurationSeconds   *prometheus.HistogramVec
+	githubWorkflowJobStepDurationSeconds  *prometheus.HistogramVec
 	githubWorkflowJobConclusionsTotal     = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "github_workflow_job_conclusions_total",


### PR DESCRIPTION
In order to get more detailed overview of the CI runs, we want to add a new metric github_workflow_job_step_run_duration_seconds which is give the run stats for each job in each workflow.

This way we will be able to see the full picture of the runs and see what takes the most of the time