### PR TITLE
Skip step with no conclusion

### DIFF
--- a/pkg/actionsmetrics/event_reader.go
+++ b/pkg/actionsmetrics/event_reader.go
@@ -216,14 +216,16 @@ func (reader *EventReader) ProcessWorkflowJobEvent(ctx context.Context, event in
 		if *e.WorkflowJob.Conclusion == "success" && repoName == "client" {
 			for _, step := range e.WorkflowJob.Steps {
 				conclusion := step.Conclusion
-				if conclusion == nil {
+				startedAt := step.StartedAt
+				completedAt := step.CompletedAt
+				if conclusion == nil || startedAt == nil || completedAt == nil {
 					continue
 				}
 
 				stepLabels := extraLabel("step_name", *step.Name, labels)
 				stepLabels["step_conclusion"] = *conclusion
 
-				stepDuration := step.CompletedAt.Sub(step.StartedAt.Time)
+				stepDuration := completedAt.Sub(startedAt.Time)
 
 				githubWorkflowJobStepDurationSeconds.With(stepLabels).Observe(stepDuration.Seconds())
 

--- a/pkg/actionsmetrics/event_reader.go
+++ b/pkg/actionsmetrics/event_reader.go
@@ -215,14 +215,19 @@ func (reader *EventReader) ProcessWorkflowJobEvent(ctx context.Context, event in
 
 		if *e.WorkflowJob.Conclusion == "success" && repoName == "client" {
 			for _, step := range e.WorkflowJob.Steps {
+				conclusion := step.Conclusion
+				if conclusion == nil {
+					continue
+				}
+
 				stepLabels := extraLabel("step_name", *step.Name, labels)
-				stepLabels["step_conclusion"] = *step.Conclusion
+				stepLabels["step_conclusion"] = *conclusion
 
 				stepDuration := step.CompletedAt.Sub(step.StartedAt.Time)
 
 				githubWorkflowJobStepDurationSeconds.With(stepLabels).Observe(stepDuration.Seconds())
 
-				log.Info("processed step in the repository", "repo", repoName, "step_name", *step.Name, "step_conclusion", *step.Conclusion)
+				log.Info("processed step in the repository", "repo", repoName, "step_name", *step.Name, "step_conclusion", *conclusion)
 			}
 		}
 	}


### PR DESCRIPTION
There are two ways a step in a job may be skipped:

- Step skipped due to an `if:` conditional: When a step has an `if:` condition that evaluates to `false`, the step is never sent to the runner for execution. In this case, the steps array in the workflow_job webhook payload will show the step, but its conclusion will be `null`.

For this part we check the step.conclusion and ignore those that are not ran.

- Step skipped due to a previous `step failure`: This is the case when the step is marked with conclusion 'skipped'. If a previous step fails, all subsequent steps in the same job are immediately skipped. Their conclusion will be 'skipped'.

For this part we doublecheck the step duration and ignore if it is not set